### PR TITLE
feat: show photo markers on map based on location

### DIFF
--- a/lib/screens/map.dart
+++ b/lib/screens/map.dart
@@ -1,35 +1,167 @@
+import 'dart:typed_data';
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:untitled/utils/PhotoQuery.dart';
 import 'package:untitled/widgets.dart';
 
-class Map extends StatelessWidget {
+class Map extends StatefulWidget {
+  @override
+  _MapState createState() => _MapState();
+}
+
+class _MapState extends State<Map> {
+  late LatLng _initialPosition = LatLng(33.6043888, 73.11627440000002);
+  Set<Marker> _markers = Set();
+  List<PhotoData> _photos = [];
+  List<GlobalKey> _markerIconKeys = [];
+  Set<String> renderedMarkers = Set();
+  LatLng cameraPositionForFetchingRecords =
+      LatLng(33.6043888, 73.11627440000002);
+  @override
+  void initState() {
+    _getPhotos();
+    super.initState();
+  }
+
+  Future<void> _getPhotos() async {
+    PhotoQuery query = PhotoQuery(
+        LatLng(cameraPositionForFetchingRecords.latitude - 5,
+            cameraPositionForFetchingRecords.longitude - 5),
+        LatLng(cameraPositionForFetchingRecords.latitude + 5,
+            cameraPositionForFetchingRecords.longitude + 5));
+    _photos = await query.getPhotos();
+
+    _photos.forEach((user) {
+      _markerIconKeys.add(GlobalKey());
+    });
+    setState(() {});
+  }
+
   @override
   Widget build(BuildContext context) {
     return SafeArea(
-        child: Scaffold(
-      body: Stack(
-        children: <Widget>[
-          GoogleMap(
-            initialCameraPosition: CameraPosition(
-              target: LatLng(37.77483, -122.41942),
-              zoom: 10,
-            ),
-          ),
-          AddLocationIcon()
-        ],
+      child: Scaffold(
+        body: Stack(
+          children: [
+            if (_photos.isNotEmpty) _buildMarkerIconsContainer(),
+            _buildBody(),
+            AddLocationIcon()
+          ],
+        ),
+        floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
+        floatingActionButton: FloatingActionButton.extended(
+          onPressed: () {
+            Navigator.pushNamed(context, '/feed');
+          },
+          icon: Icon(Icons.view_stream),
+          label: Text("Feed"),
+          backgroundColor: Colors.white.withOpacity(0.9),
+          foregroundColor: Colors.black,
+          shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.all(Radius.circular(10.0))),
+        ),
       ),
-      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
-      floatingActionButton: FloatingActionButton.extended(
-        onPressed: () {
-          Navigator.pushNamed(context, '/feed');
-        },
-        icon: Icon(Icons.view_stream),
-        label: Text("Feed"),
-        backgroundColor: Colors.white.withOpacity(0.9),
-        foregroundColor: Colors.black,
-        shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.all(Radius.circular(10.0))),
+    );
+  }
+
+  Widget _buildMarkerIconsContainer() {
+    return Column(
+      children: _buildMarkerIcons(),
+    );
+  }
+
+  List<Widget> _buildMarkerIcons() {
+    List<Widget> icons = [];
+    for (int i = 0; i < _photos.length; i++) {
+      icons.add(_buildMarkerIcon(i));
+    }
+    return icons;
+  }
+
+  Widget _buildMarkerIcon(int index) {
+    PhotoData photo = _photos[index];
+    var image = NetworkImage(photo.url);
+
+    image.resolve(ImageConfiguration()).addListener(
+      ImageStreamListener((info, call) {
+        _addMarker(photo, index);
+      }),
+    );
+    return RepaintBoundary(
+      key: _markerIconKeys[index],
+      child: Material(
+        shape: CircleBorder(),
+        clipBehavior: Clip.hardEdge,
+        child: Image(
+          image: image,
+          fit: BoxFit.fill,
+          width: 40,
+          height: 40,
+        ),
       ),
-    ));
+    );
+  }
+
+  void _addMarker(PhotoData user, int index) async {
+    Future.delayed(Duration(seconds: 1)).then((value) async {
+      if (renderedMarkers.contains(user.url)) return;
+
+      var markerBytes = await _getMarkerIconBytes(_markerIconKeys[index]);
+      if (markerBytes == null) return;
+
+      _markers.add(Marker(
+          markerId: MarkerId(user.url),
+          position: user.location,
+          icon: BitmapDescriptor.fromBytes(markerBytes)));
+      renderedMarkers.add(user.url);
+      setState(() {});
+    });
+  }
+
+  Future<Uint8List?> _getMarkerIconBytes(GlobalKey markerKey) async {
+    if (markerKey.currentContext == null) return null;
+
+    RenderRepaintBoundary boundary =
+        markerKey.currentContext?.findRenderObject() as RenderRepaintBoundary;
+    var image = await boundary.toImage(pixelRatio: 2.0);
+    ByteData byteData = (await image.toByteData(format: ImageByteFormat.png))!;
+    return byteData.buffer.asUint8List();
+  }
+
+  _onCameraMove(CameraPosition position) {
+    bool fetchNewRecords = cameraPositionForFetchingRecords.longitude -
+                position.target.longitude <
+            -10 ||
+        cameraPositionForFetchingRecords.longitude + position.target.longitude >
+                10 &&
+            cameraPositionForFetchingRecords.latitude -
+                    position.target.latitude <
+                -10 ||
+        cameraPositionForFetchingRecords.latitude + position.target.latitude >
+            10;
+
+    if (fetchNewRecords) {
+      cameraPositionForFetchingRecords = position.target;
+      _getPhotos();
+    }
+  }
+
+  Widget _buildBody() {
+    if (_initialPosition == null)
+      return Container(
+        width: double.infinity,
+        height: double.infinity,
+        color: Colors.white,
+        child: Center(child: Text('Loading...')),
+      );
+
+    return GoogleMap(
+      initialCameraPosition: CameraPosition(target: _initialPosition, zoom: 15),
+      markers: _markers,
+      onCameraMove: _onCameraMove,
+    );
   }
 }

--- a/lib/utils/PhotoQuery.dart
+++ b/lib/utils/PhotoQuery.dart
@@ -34,7 +34,6 @@ class PhotoQuery {
       photos.add(PhotoData(LatLng(geoPoint.latitude, geoPoint.longitude),
           document.data()!["uid"], document.data()!["downloadUrl"]));
     });
-    print(photos);
     return photos;
   }
 }

--- a/lib/utils/PhotoUploader.dart
+++ b/lib/utils/PhotoUploader.dart
@@ -1,9 +1,7 @@
-import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:untitled/models/Photo.dart';
 import 'package:firebase_storage/firebase_storage.dart' as firebase_storage;
 import 'package:path/path.dart' as Path;
 import 'package:cloud_firestore/cloud_firestore.dart' as Firestore;
-import 'package:untitled/utils/PhotoQuery.dart';
 
 class PhotoUploader {
   Photo photo;
@@ -23,9 +21,7 @@ class PhotoUploader {
     }).catchError((onError) {
       print("Error");
     });
-    PhotoQuery query = PhotoQuery(
-        LatLng(33.6043888, 73.11627440000002), LatLng(36.000000, 79.0000000));
-    print(await query.getPhotos());
+
     return uploading;
   }
 


### PR DESCRIPTION
Custom photo markers showed on Map based on location
Custom markers contain photo in circle, I think this look better than the one in the figma design as that will take more space on map
And there is one more problem with current design that on marker click we want it to navigate to photo_detail screen but let suppose user have taken 3 photos in same place and on map they are on the same place, we will be only able to see the photo that is on top of stack for markers.
I think we should use bottom sheet instead, for example when user click photo show that in bottom sheet and if more than one picture share the same location(GeoPoint) then we can list all photos in bottom sheet
close #5